### PR TITLE
Added props tracksViewChanges and onMarkerRendered

### DIFF
--- a/MapView/MapWithClustering.js
+++ b/MapView/MapWithClustering.js
@@ -147,6 +147,8 @@ export default class MapWithClustering extends Component {
         marker={cluster.properties.point_count === 0 ? cluster.marker : null}
         key={JSON.stringify(cluster.geometry) + cluster.properties.cluster_id + cluster.properties.point_count}
         onClusterPress={this.props.onClusterPress}
+        onMarkerRendered={this.props.onMarkerRendered}
+        tracksViewChanges={this.props.tracksViewChanges}
       />));
     } else {
       clusteredMarkers = this.state.markers.map(marker => marker.marker);


### PR DESCRIPTION
These props will be passed to the CustomDefinedMarker to have control on the rendering state of the Marker element (e.g. when it has an image or is animated it could be slow to load). 

* `tracksViewChanges: boolean;`
will be passed as prop to the marker element (e.g. `<Marker tracksViewChanges={this.props.tracksViewChanges}/>`)
* `onMarkerRendered: () => void;`
will be called when the marker elements has completed rendering (e.g. `<Marker><Image onLoad={this.props.onMarkerRendered}/></Marker>`)